### PR TITLE
Remove dependency on Chef gem, fixes #3

### DIFF
--- a/knife-config.gemspec
+++ b/knife-config.gemspec
@@ -12,5 +12,4 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/jtimberman/knife-config"
   s.require_path = 'lib'
   s.files = %w(LICENSE README.md) + Dir.glob("lib/**/*")
-  s.add_dependency('chef', '>= 0.10.0')
 end


### PR DESCRIPTION
This plugin lives within the Chef tools ecosystem. If it depends on the Chef gem, then it can install a newer version than the one installed in certain circumstances.
